### PR TITLE
@roryp2 Don't write file out in errorHandler due to no screenshot

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -38,7 +38,7 @@ function setupSeleniumAndRunTests(config, options) {
         }, err => {
             if (err) {
                 console.error(`Selenium installation Error! ${err}`);
-                throw err;
+                process.exit(1);
             }
 
             startSeleniumAndRunTests(config, options, (err, results) => {
@@ -73,7 +73,7 @@ function setupBrowserStackAndRunTests(config, options) {
     runTests(client, config, options, (err, results) => {
         if (err) {
             console.error(`Run Tests Error! ${err}`);
-            throw err;
+            process.exit(1);
         }
         console.log('Finished Tests. Comparing Results.');
         submitAndCompare(config.scholarUrl, results, handleImageComparison);
@@ -93,7 +93,7 @@ function startSeleniumAndRunTests(config, options, callback) {
 
         if (err) {
             console.error(`Selenium start Error! ${err}`);
-            throw err;
+            process.exit(1);
         }
 
         process.on('uncaughtException', (err) => {
@@ -213,13 +213,9 @@ function runTests(client, config, options, completionCallback) {
 
     function errorHandler(scenarioName, err, callback) {
         console.log(`${scenarioName} failed! Error: ${err.message || JSON.stringify(err)}`);
-        fs.writeFile(path.join(process.cwd(), options.output, `${options.browser}-${scenarioName}-ERROR.png`), new Buffer(err.screenshot, 'base64'), 'utf8', function () {
-            callback({
-                type: err.type,
-                message: err.message
-            });
-
-            process.exit(1);
+        callback({
+            type: err.type,
+            message: err.message
         });
     }
 
@@ -227,7 +223,7 @@ function runTests(client, config, options, completionCallback) {
         console.log('Finished Specs! Killing client');
         if (err) {
             console.error('Test Execution Error: ', err);
-            throw err;
+            process.exit(1);
         }
 
         client
@@ -242,7 +238,7 @@ function runTests(client, config, options, completionCallback) {
 function handleImageComparison(err, comparisonResults) {
     if (err) {
         console.error(`Error passed to handleImageComparison! ${err}`);
-        throw err;
+        process.exit(1);
     }
     console.log('Final process complete, images submitted and compared.');
     let errorArray = comparisonResults


### PR DESCRIPTION
existing. Exit process correctly in error situations

Exit process in error situations correctly.

Remove code to save screenshot in errorHandler as screenshot does not exist

@roryp2
