### PR TITLE
Improve quality of IE and Firefox screenshots

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -8,13 +8,15 @@ const $ = require('async');
 const fs = require('fs');
 const submitAndCompare = require('./submit');
 const captureAndCrop = require('./capture');
+const includes = require('lodash.includes');
 
 let appConfig;
-let browserCrop = {
+const browserCrop = {
     chrome: true,
     edge: true,
     safari: true
 };
+const fullPageScreenshotBrowsers = ['firefox', 'ie'];
 
 module.exports = function (config, options) {
     appConfig = config;
@@ -175,8 +177,13 @@ function runTests(client, config, options, completionCallback) {
                 .runCommands(setupFunction)
                 .pause(scenario.setupTimeout || 0)
                 .waitForVisible(selector, waitTimeout)
-                .scroll(selector, scrollOffsetX, scrollOffsetY)
-                .getLocationInView(selector)
+                .then(() => {
+                    if (!includes(fullPageScreenshotBrowsers, options.browser)) {
+                        return client.scroll(selector, scrollOffsetX, scrollOffsetY).getLocationInView(selector);
+                    } else {
+                        return client.getLocation(selector);
+                    }
+                })
                 .then(result => {
                     conditionalLog('Element Position', result);
                     elementBox = {
@@ -196,8 +203,8 @@ function runTests(client, config, options, completionCallback) {
                     let cropRectangle = {
                         left: elementBox.left,
                         top: elementBox.top,
-                        width: browserCrop[options.browser] ? Math.min(elementBox.width, size.width) : elementBox.width,
-                        height: browserCrop[options.browser] ? Math.min(elementBox.height, size.height) : elementBox.height
+                        width: Math.min(elementBox.width, size.width),
+                        height: Math.min(elementBox.height, size.height)
                     };
                     conditionalLog('Final Crop Rectangle', cropRectangle);
                     return client
@@ -208,7 +215,6 @@ function runTests(client, config, options, completionCallback) {
                         .catch(err => {
                             errorHandler(scenario.name, err, scenarioCallback)
                         });
-
                 })
                 .catch(err => {
                     return errorHandler(scenario.name, err, scenarioCallback)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "commander": "2.9.0",
     "console.table": "0.4.0",
     "jimp": "0.2.21",
+    "lodash.includes": "4.1.3",
     "lodash.merge": "4.3.5",
     "lodash.pick": "4.1.1",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
Improve quality of IE and Firefox screenshots by not scrolling elements into view. This is because these browsers take a full page screenshot rather than just the viewport.

@roryp2
