### PR TITLE
updated to include a runner flag which allows remote selenium to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This is the client test runner for usage with the [Scholar application](http://g
         -b, --browser <option>           Define test browser (defaults to "phantomjs")
         --browserstack                   Define whether to use browserstack
         --browserstackLocal <bool>       Defined browserstack local value (defaults to true)
+        -r, --runner <option>            Define the runner for the tests e.g. local, browserstack, remoteSelenium (defaults to "local")
         --seleniumVersion <version>      Optionally use a specific selenium version
         --verbose                        Define selenium log level
         -s, --suite <suite>              Define file to run (optional)
@@ -98,10 +99,26 @@ To run on browserstack you will need to:
         }
     }
 
+### RemoteSelenium
+
+To run on remoteSelenium you will need to define the following in the config:
+
+*   host : the host name for the remoteSelenium server
+*   port : port number for the remoteSelenium server,
+
+For Example:
+   
+    module.exports = {
+          baseUrl: 'http://the-website-you-want-to-test.com',
+          scholarUrl: 'http://your-scholar-instance.com'
+          host: 'localhost',
+          port: '4445'
+    };
 
 ## Writing Specs
 
 ### Your first spec file
+
 
 Within your test directory (defaults to test/) add your spec file. Ensure the ending contains '-spec.js';
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ This is the client test runner for usage with the [Scholar application](http://g
         -h, --help                       output usage information
         -V, --version                    output the version number
         -b, --browser <option>           Define test browser (defaults to "phantomjs")
-        --browserstack                   Define whether to use browserstack
-        --browserstackLocal <bool>       Defined browserstack local value (defaults to true)
-        -r, --runner <option>            Define the runner for the tests e.g. local, browserstack, remoteSelenium (defaults to "local")
+        -r, --runner <option>            Define the runner for the tests e.g. local, remote (defaults to "local")
         --seleniumVersion <version>      Optionally use a specific selenium version
         --verbose                        Define selenium log level
         -s, --suite <suite>              Define file to run (optional)
@@ -57,21 +55,38 @@ Add required cookies to your config file,
       }]
     };
 
-### Browserstack
+### Remote
+
+To run on a remote Selenium server you will need to:
+
+* Set the runner flag to remote
+* Set the Host (required) and Port number (optional) up in your config
+
+For Example:
+
+    module.exports = {
+          baseUrl: 'http://the-website-you-want-to-test.com',
+          scholarUrl: 'http://your-scholar-instance.com'
+          host: 'http://your-Selenium-server.com',
+          port: 'your-Selenium-server-port'
+    };
+
 
 To run on browserstack you will need to:
 
 * Define the `BROWSERSTACK_USER` environment variable as your browserstack user.
 * Define the `BROWSERSTACK_KEY` environment variable as your browserstack automation key.
-* Add the `--browserstack` flag to the CLI tool.
 * If you want to test somewhere not internet accessible (localhost / internal domain etc) you will need to start up the browserstack local tunnel CLI. It's not included with this package, however it is easy to setup like:
     * wget https://www.browserstack.com/browserstack-local/BrowserStackLocal-`YOURENVNAME`-x64.zip && unzip BrowserStackLocal-`YOURENVNAME`-x64.zip
     * ./BrowserStackLocal -v -onlyAutomate -forcelocal $BROWSERSTACK_KEY &
-* If you want more options then pass in 'browserstack' object in your appConfig, which will be used as your browser desiredCapabilities.
+* If you want more options then pass in 'browserstack' object in your appConfig, which will be used as your browser desiredCapabilities. 
+* If you need to run browserstack over a local/private connection add 'browserstack.local' : true to the config file 
 
+An Example browserstack config:
 
     {
         browserstack: {
+            'browserstack.local' : true,
             ie: {
                 browser: 'IE',
                 browser_version: '11',
@@ -98,22 +113,6 @@ To run on browserstack you will need to:
             }
         }
     }
-
-### RemoteSelenium
-
-To run on remoteSelenium you will need to define the following in the config:
-
-*   host : the host name for the remoteSelenium server
-*   port : port number for the remoteSelenium server,
-
-For Example:
-   
-    module.exports = {
-          baseUrl: 'http://the-website-you-want-to-test.com',
-          scholarUrl: 'http://your-scholar-instance.com'
-          host: 'localhost',
-          port: '4445'
-    };
 
 ## Writing Specs
 

--- a/README.md
+++ b/README.md
@@ -61,21 +61,25 @@ To run on a remote Selenium server you will need to:
 
 * Set the runner flag to remote
 * Set the Host (required) and Port number (optional) up in your config
+* Set the user variable in config to your Selenium login (optional)
+* Set the key variable in config to your automation key (optional)
 
 For Example:
 
     module.exports = {
           baseUrl: 'http://the-website-you-want-to-test.com',
-          scholarUrl: 'http://your-scholar-instance.com'
+          scholarUrl: 'http://your-scholar-instance.com',
           host: 'http://your-Selenium-server.com',
-          port: 'your-Selenium-server-port'
+          port: 'your-Selenium-server-port',
+          user: 'user-name',
+          key: 'automation-key'
     };
 
 
 To run on browserstack you will need to:
 
-* Define the `browserstack.user` variable as your browserstack user in your config.
-* Define the `browserstack.key` variable as your browserstack automation key in your config.
+* Define the `user` variable as your browserstack user in config.
+* Define the `key` variable as your browserstack automation key in config.
 * If you want to test somewhere not internet accessible (localhost / internal domain etc) you will need to start up the browserstack local tunnel CLI. It's not included with this package, however it is easy to setup like:
     * wget https://www.browserstack.com/browserstack-local/BrowserStackLocal-`YOURENVNAME`-x64.zip && unzip BrowserStackLocal-`YOURENVNAME`-x64.zip
     * ./BrowserStackLocal -v -onlyAutomate -forcelocal $BROWSERSTACK_KEY &
@@ -85,9 +89,12 @@ To run on browserstack you will need to:
 An Example browserstack config:
 
     {
+        baseUrl: 'http://the-website-you-want-to-test.com',
+        scholarUrl: 'http://your-scholar-instance.com',
+        host: 'hub.browserstack.com',
+        user: 'browserstack-user-name',
+        key: 'browserstack-automation-key',
         browserstack: {
-            user: 'browserstack-user-name',
-            key: 'browserstack-automation-key',
             'browserstack.local' : true,
             ie: {
                 browser: 'IE',

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ For Example:
 
 To run on browserstack you will need to:
 
-* Define the `BROWSERSTACK_USER` environment variable as your browserstack user.
-* Define the `BROWSERSTACK_KEY` environment variable as your browserstack automation key.
+* Define the `browserstack.user` variable as your browserstack user in your config.
+* Define the `browserstack.key` variable as your browserstack automation key in your config.
 * If you want to test somewhere not internet accessible (localhost / internal domain etc) you will need to start up the browserstack local tunnel CLI. It's not included with this package, however it is easy to setup like:
     * wget https://www.browserstack.com/browserstack-local/BrowserStackLocal-`YOURENVNAME`-x64.zip && unzip BrowserStackLocal-`YOURENVNAME`-x64.zip
     * ./BrowserStackLocal -v -onlyAutomate -forcelocal $BROWSERSTACK_KEY &
@@ -86,6 +86,8 @@ An Example browserstack config:
 
     {
         browserstack: {
+            user: 'browserstack-user-name',
+            key: 'browserstack-automation-key',
             'browserstack.local' : true,
             ie: {
                 browser: 'IE',

--- a/index.js
+++ b/index.js
@@ -12,9 +12,7 @@ var testHelper = require('./helpers/fetchTests');
 program
     .version(packageJson.version)
     .option('-b, --browser <option>', 'Define test browser (defaults to "phantomjs")', 'phantomjs')
-    .option('--browserstack', 'Define whether to use browserstack')
-    .option('-r, --runner <option>', 'Define the runner for the tests e.g. local, browserstack, remoteSelenium (defaults to "local")', 'local')
-    .option('--browserstackLocal <bool>', 'Defined browserstack local value (defaults to true)', true)
+    .option('-r, --runner <option>', 'Define the runner for the tests e.g. local, remote (defaults to "local")', 'local')
     .option('--seleniumVersion <version>', 'Optionally use a specific selenium version', '2.53.0')
     .option('--verbose', 'Define selenium log level')
     .option('-s, --suite <suite>', 'Define file to run (optional)')
@@ -32,14 +30,12 @@ pipeHelper(mergeData);
 
 function mergeData(parsedData) {
     merge(appConfig, parsedData);
-    options = pick(program, ['browser', 'browserstack', 'browserstackLocal', 'verbose', 'seleniumVersion', 'output']);
+    options = pick(program, ['browser', 'runner', 'verbose', 'seleniumVersion', 'output']);
     testHelper(program.directory, program.suite, program.type, generateSpecs);
 }
 
 function generateSpecs(testResults) {
     options.scenarios = testResults;
-    if (program.browserstack) appConfig.runner = 'browserstack';
-    if (program.runner) appConfig.runner = program.runner;
     if (program.browser === 'phantom') options.browser = 'phantomjs';
     require('./lib/runner')(appConfig, options)
 }

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ program
     .version(packageJson.version)
     .option('-b, --browser <option>', 'Define test browser (defaults to "phantomjs")', 'phantomjs')
     .option('--browserstack', 'Define whether to use browserstack')
+    .option('-r, --runner <option>', 'Define the runner for the tests e.g. local, browserstack, remoteSelenium (defaults to "local")', 'local')
     .option('--browserstackLocal <bool>', 'Defined browserstack local value (defaults to true)', true)
     .option('--seleniumVersion <version>', 'Optionally use a specific selenium version', '2.53.0')
     .option('--verbose', 'Define selenium log level')
@@ -37,7 +38,8 @@ function mergeData(parsedData) {
 
 function generateSpecs(testResults) {
     options.scenarios = testResults;
-    appConfig.runner = program.browserstack ? 'browserstack' : 'local';
+    if (program.browserstack) appConfig.runner = 'browserstack';
+    if (program.runner) appConfig.runner = program.runner;
     if (program.browser === 'phantom') options.browser = 'phantomjs';
     require('./lib/runner')(appConfig, options)
 }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -21,15 +21,10 @@ const fullPageScreenshotBrowsers = ['firefox', 'ie'];
 module.exports = function (config, options) {
     appConfig = config;
 
-    switch (config.runner) {
-        case 'browserstack':
-            setupBrowserStackAndRunTests(config, options);
-            break;
-        case 'remoteSelenium' :
-            connectToRemoteSeleniumAndRunTests(config, options);
-            break;
-        default:
-            setupSeleniumAndRunTests(config, options);
+    if (options.runner === 'remote') {
+        setupRemoteSessionAndRunTests(config, options)
+    } else {
+        setupSeleniumAndRunTests(config, options);
     }
 };
 
@@ -56,8 +51,8 @@ function setupSeleniumAndRunTests(config, options) {
         });
 }
 
-function setupBrowserStackAndRunTests(config, options) {
-    console.log('Starting Up BrowserStack Connection.');
+function setupRemoteSessionAndRunTests(config, options) {
+    console.log('Starting Up Remote Connection.');
 
     process.on('uncaughtException', (err) => {
         console.error(`Caught exception: ${err.stack || JSON.stringify(err)}`);
@@ -69,43 +64,17 @@ function setupBrowserStackAndRunTests(config, options) {
             platform: "ANY"
         };
     browserOptions['browserstack.local'] = options.browserstackLocal;
-
     let bsOptions = {
         "logLevel": options.verbose ? "verbose" : "silent",
         "desiredCapabilities": browserOptions,
         "user": process.env.BROWSERSTACK_USER,
         "key": process.env.BROWSERSTACK_KEY,
-        "host": 'hub.browserstack.com',
+        "host": config.host,
+        "port": config.port? config.port : 4444,
         "phantomjs.binary.path": 'node_modules/.bin/phantomjs'
     };
 
     let client = webdriverio.remote(bsOptions).init();
-
-    runTests(client, config, options, (err, results) => {
-        if (err) {
-            console.error(`Run Tests Error! ${err}`);
-            process.exit(1);
-        }
-        console.log('Finished Tests. Comparing Results.');
-        submitAndCompare(config.scholarUrl, results, handleImageComparison);
-    });
-}
-
-function connectToRemoteSeleniumAndRunTests(config, options) {
-    console.log('Starting Up RemoteSelenium Connection.');
-    process.on('uncaughtException', (err) => {
-        console.error(`Caught exception: ${err.stack || JSON.stringify(err)}`);
-        process.exit(1);
-    });
-
-    let rsOptions = {
-        "logLevel": options.verbose ? "verbose" : "silent",
-        "desiredCapabilities": {browserName: options.browser},
-        "host": config.host,
-        "port": config.port
-    };
-
-    let client = webdriverio.remote(rsOptions).init();
 
     runTests(client, config, options, (err, results) => {
         if (err) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -21,10 +21,15 @@ const fullPageScreenshotBrowsers = ['firefox', 'ie'];
 module.exports = function (config, options) {
     appConfig = config;
 
-    if (config.runner === 'browserstack') {
-        setupBrowserStackAndRunTests(config, options);
-    } else {
-        setupSeleniumAndRunTests(config, options);
+    switch (config.runner) {
+        case 'browserstack':
+            setupBrowserStackAndRunTests(config, options);
+            break;
+        case 'remoteSelenium' :
+            connectToRemoteSeleniumAndRunTests(config, options);
+            break;
+        default:
+            setupSeleniumAndRunTests(config, options);
     }
 };
 
@@ -52,17 +57,19 @@ function setupSeleniumAndRunTests(config, options) {
 }
 
 function setupBrowserStackAndRunTests(config, options) {
+    console.log('Starting Up BrowserStack Connection.');
+
     process.on('uncaughtException', (err) => {
         console.error(`Caught exception: ${err.stack || JSON.stringify(err)}`);
         process.exit(1);
     });
-    
+
     let browserOptions = config.browserstack && config.browserstack[options.browser] || {
             browserName: options.browser,
             platform: "ANY"
         };
     browserOptions['browserstack.local'] = options.browserstackLocal;
-    
+
     let bsOptions = {
         "logLevel": options.verbose ? "verbose" : "silent",
         "desiredCapabilities": browserOptions,
@@ -73,6 +80,32 @@ function setupBrowserStackAndRunTests(config, options) {
     };
 
     let client = webdriverio.remote(bsOptions).init();
+
+    runTests(client, config, options, (err, results) => {
+        if (err) {
+            console.error(`Run Tests Error! ${err}`);
+            process.exit(1);
+        }
+        console.log('Finished Tests. Comparing Results.');
+        submitAndCompare(config.scholarUrl, results, handleImageComparison);
+    });
+}
+
+function connectToRemoteSeleniumAndRunTests(config, options) {
+    console.log('Starting Up RemoteSelenium Connection.');
+    process.on('uncaughtException', (err) => {
+        console.error(`Caught exception: ${err.stack || JSON.stringify(err)}`);
+        process.exit(1);
+    });
+
+    let rsOptions = {
+        "logLevel": options.verbose ? "verbose" : "silent",
+        "desiredCapabilities": {browserName: options.browser},
+        "host": config.host,
+        "port": config.port
+    };
+
+    let client = webdriverio.remote(rsOptions).init();
 
     runTests(client, config, options, (err, results) => {
         if (err) {
@@ -129,7 +162,7 @@ function startSeleniumAndRunTests(config, options, callback) {
 function runTests(client, config, options, completionCallback) {
 
     function conditionalLog() {
-        if(options.verbose) console.log.apply(console, arguments);
+        if (options.verbose) console.log.apply(console, arguments);
     }
 
     client.addCommand('loadCookies', function (cookies) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -63,17 +63,13 @@ function setupRemoteSessionAndRunTests(config, options) {
             browserName: options.browser,
             platform: "ANY"
         };
-    let bsOptions = {
+    let baseOptions = {
         "logLevel": options.verbose ? "verbose" : "silent",
         "desiredCapabilities": browserOptions,
-        "user": config.browserstack ? config.browserstack.user : '',
-        "key": config.browserstack ? config.browserstack.key : '',
-        "host": config.host,
-        "port": config.port? config.port : 4444,
         "phantomjs.binary.path": 'node_modules/.bin/phantomjs'
     };
-
-    let client = webdriverio.remote(bsOptions).init();
+    let webdriverConfig = Object.assign(baseOptions, config);
+    let client = webdriverio.remote(webdriverConfig).init();
 
     runTests(client, config, options, (err, results) => {
         if (err) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -63,12 +63,11 @@ function setupRemoteSessionAndRunTests(config, options) {
             browserName: options.browser,
             platform: "ANY"
         };
-    browserOptions['browserstack.local'] = options.browserstackLocal;
     let bsOptions = {
         "logLevel": options.verbose ? "verbose" : "silent",
         "desiredCapabilities": browserOptions,
-        "user": process.env.BROWSERSTACK_USER,
-        "key": process.env.BROWSERSTACK_KEY,
+        "user": config.browserstack ? config.browserstack.user : '',
+        "key": config.browserstack ? config.browserstack.key : '',
         "host": config.host,
         "port": config.port? config.port : 4444,
         "phantomjs.binary.path": 'node_modules/.bin/phantomjs'


### PR DESCRIPTION
We needed to extend scholar-runner so that we can run it over a selenium server within a Docker environment.

We added a runner option where you can specific where to run the tests e.g. local, remote or broswerstack, we left the broswerstack flag in just so that we don't create a braking change, and added the code to run with a remote selenium server
